### PR TITLE
Fixed moved url genericadmin-init

### DIFF
--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -12,7 +12,7 @@
     var GenericAdmin = {
         url_array: null,
         fields: null,
-        obj_url: "../obj-data/",
+        obj_url: "../../obj-data/",
         admin_media_url: window.__admin_media_prefix__,
 		popup: '_popup',
         
@@ -306,7 +306,7 @@
 
     $(document).ready(function() {
         $.ajax({
-            url: '../genericadmin-init/',
+            url: '../../genericadmin-init/',
             dataType: 'json',
             success: function(data) {
                 var url_array = data.url_array,


### PR DESCRIPTION
I was getting the following error in the logs:
127.0.0.1 - - [24/Jan/2016 22:49:07] "GET /admin/dialer_cdr/callrequest/117/genericadmin-init/ HTTP/1.1" 302 -
127.0.0.1 - - [24/Jan/2016 22:49:07] "GET /admin/dialer_cdr/callrequest/117/genericadmin-init/change/ HTTP/1.1" 404 -

but I could not find anything that was really broken.
